### PR TITLE
Add user login and track sales per user

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -2,25 +2,26 @@
 from sqlalchemy import Column, Integer, String, Float, Boolean, DateTime, ForeignKey, Text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
 from datetime import datetime
 
 Base = declarative_base()
 
+
 class Category(Base):
     __tablename__ = "categories"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(100), nullable=False, unique=True)
     description = Column(Text)
     created_at = Column(DateTime, default=datetime.now)
-    
-    # Relationship
+
+    # Relationships
     products = relationship("Product", back_populates="category")
+
 
 class Product(Base):
     __tablename__ = "products"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(200), nullable=False)
     description = Column(Text)
@@ -34,15 +35,16 @@ class Product(Base):
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=datetime.now)
     updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now)
-    
+
     # Relationships
     category = relationship("Category", back_populates="products")
     sale_items = relationship("SaleItem", back_populates="product")
     stock_movements = relationship("StockMovement", back_populates="product")
 
+
 class Customer(Base):
     __tablename__ = "customers"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(200), nullable=False)
     phone = Column(String(20))
@@ -52,13 +54,28 @@ class Customer(Base):
     current_credit = Column(Float, default=0.0)
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=datetime.now)
-    
+
     # Relationships
     sales = relationship("Sale", back_populates="customer")
 
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(100), unique=True, nullable=False)
+    password_hash = Column(String(255), nullable=False)
+    role = Column(String(50), default="cashier")
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.now)
+
+    # Relationships
+    sales = relationship("Sale", back_populates="user")
+
+
 class Sale(Base):
     __tablename__ = "sales"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     sale_number = Column(String(50), unique=True, nullable=False)
     customer_id = Column(Integer, ForeignKey("customers.id"), nullable=True)
@@ -72,15 +89,17 @@ class Sale(Base):
     change_amount = Column(Float, default=0.0)
     notes = Column(Text)
     created_at = Column(DateTime, default=datetime.now)
-    cashier = Column(String(100))
-    
+    user_id = Column(Integer, ForeignKey("users.id"))
+
     # Relationships
     customer = relationship("Customer", back_populates="sales")
     sale_items = relationship("SaleItem", back_populates="sale")
+    user = relationship("User", back_populates="sales")
+
 
 class SaleItem(Base):
     __tablename__ = "sale_items"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     sale_id = Column(Integer, ForeignKey("sales.id"))
     product_id = Column(Integer, ForeignKey("products.id"))
@@ -88,14 +107,15 @@ class SaleItem(Base):
     unit_price = Column(Float, nullable=False)
     total_price = Column(Float, nullable=False)
     discount_amount = Column(Float, default=0.0)
-    
+
     # Relationships
     sale = relationship("Sale", back_populates="sale_items")
     product = relationship("Product", back_populates="sale_items")
 
+
 class StockMovement(Base):
     __tablename__ = "stock_movements"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     product_id = Column(Integer, ForeignKey("products.id"))
     movement_type = Column(String(20), nullable=False)  # in, out, adjustment
@@ -105,15 +125,17 @@ class StockMovement(Base):
     notes = Column(Text)
     created_at = Column(DateTime, default=datetime.now)
     created_by = Column(String(100))
-    
+
     # Relationships
     product = relationship("Product", back_populates="stock_movements")
 
+
 class Setting(Base):
     __tablename__ = "settings"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     key = Column(String(100), unique=True, nullable=False)
     value = Column(Text)
     description = Column(Text)
     updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now)
+

--- a/gui/login_window.py
+++ b/gui/login_window.py
@@ -1,0 +1,55 @@
+"""Login window for the POS system."""
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from database.database import db_manager
+from database.models import User
+from utils.auth import verify_password, set_current_user
+
+
+class LoginWindow:
+    """Simple modal login window."""
+
+    def __init__(self, root: tk.Toplevel):
+        self.root = root
+        self.root.title("User Login")
+        self.root.geometry("300x160")
+        self.user = None
+
+        frame = ttk.Frame(root, padding=10)
+        frame.pack(fill="both", expand=True)
+
+        ttk.Label(frame, text="Username:").grid(row=0, column=0, sticky=tk.W)
+        self.username_var = tk.StringVar()
+        ttk.Entry(frame, textvariable=self.username_var).grid(row=0, column=1, pady=5)
+
+        ttk.Label(frame, text="Password:").grid(row=1, column=0, sticky=tk.W)
+        self.password_var = tk.StringVar()
+        ttk.Entry(frame, textvariable=self.password_var, show="*").grid(row=1, column=1, pady=5)
+
+        login_btn = ttk.Button(frame, text="Login", command=self.login)
+        login_btn.grid(row=2, column=0, columnspan=2, pady=10, sticky=(tk.W, tk.E))
+
+        self.root.bind("<Return>", lambda _e: self.login())
+
+    def login(self):
+        username = self.username_var.get().strip()
+        password = self.password_var.get()
+
+        session = db_manager.get_session()
+        try:
+            user = (
+                session.query(User)
+                .filter(User.username == username, User.is_active == True)
+                .first()
+            )
+            if user and verify_password(password, user.password_hash):
+                set_current_user(user)
+                self.user = user
+                self.root.destroy()
+            else:
+                messagebox.showerror("Login Failed", "Invalid username or password")
+        finally:
+            session.close()
+

--- a/gui/pos_window.py
+++ b/gui/pos_window.py
@@ -4,6 +4,7 @@ from tkinter import ttk, messagebox
 from datetime import datetime
 from database.database import db_manager, DatabaseUtils
 from database.models import Product, Sale, SaleItem, Customer, StockMovement
+from utils.auth import get_current_user
 
 class POSWindow:
     def __init__(self, parent):
@@ -555,6 +556,7 @@ class POSWindow:
         session = db_manager.get_session()
         try:
             # Create sale record
+            current_user = get_current_user()
             sale = Sale(
                 sale_number=DatabaseUtils.generate_sale_number(),
                 customer_id=customer_id,
@@ -565,7 +567,7 @@ class POSWindow:
                 payment_status="paid",
                 amount_paid=paid,
                 change_amount=max(0, paid - total_with_tax),
-                cashier="System"  # TODO: Add user management
+                user_id=current_user.id if current_user else None,
             )
             session.add(sale)
             session.flush()  # Get sale ID
@@ -594,7 +596,7 @@ class POSWindow:
                     reference_type="sale",
                     reference_id=sale.id,
                     notes=f"Sale #{sale.sale_number}",
-                    created_by="System"
+                    created_by=current_user.username if current_user else "System"
                 )
                 session.add(stock_movement)
             

--- a/main.py
+++ b/main.py
@@ -286,6 +286,8 @@ try:
     from database.database import init_database, db_manager, DatabaseUtils
     from database.models import *
     from gui.main_window import MainWindow
+    from gui.login_window import LoginWindow
+    from utils.auth import get_current_user
 except ImportError:
     try:
         import database.database as db_module
@@ -293,6 +295,8 @@ except ImportError:
         from database.models import *
         import gui.main_window as main_window_module
         from gui.main_window import MainWindow
+        from gui.login_window import LoginWindow
+        from utils.auth import get_current_user
     except ImportError:
         subdirs = ['database', 'gui', 'utils']
         for subdir in subdirs:
@@ -304,6 +308,8 @@ except ImportError:
             from database import init_database, db_manager, DatabaseUtils
             from models import *
             from main_window import MainWindow
+            from login_window import LoginWindow
+            from auth import get_current_user
         except ImportError as e:
             messagebox.showerror("Import Error", 
                                f"Failed to import required modules: {e}\n"
@@ -327,15 +333,30 @@ class ConstructionPOSApp:
         
         # Initialize database
         self.init_database()
-        
+
+        # Show login window before proceeding
+        if not self.show_login():
+            self.root.destroy()
+            self.root = None
+            return
+
         # Setup modern theme
         self.setup_modern_theme()
-        
+
         # Create main window
         self.main_window = MainWindow(self.root)
         
         # Setup menu
         self.setup_menu()
+
+    def show_login(self) -> bool:
+        """Display login window and return True if a user logged in."""
+        self.root.withdraw()
+        login_win = tk.Toplevel(self.root)
+        login_app = LoginWindow(login_win)
+        self.root.wait_window(login_win)
+        self.root.deiconify()
+        return get_current_user() is not None
         
     def setup_modern_theme(self):
         """Setup modern professional theme"""
@@ -857,6 +878,8 @@ for construction material shops and hardware stores.
     
     def run(self):
         """Start the application"""
+        if self.root is None:
+            return
         try:
             self.root.mainloop()
         except KeyboardInterrupt:

--- a/receipt_printer.py
+++ b/receipt_printer.py
@@ -110,7 +110,7 @@ class ReceiptPrinter:
             sale_info = [
                 ['Receipt #:', sale.sale_number],
                 ['Date:', sale.created_at.strftime('%Y-%m-%d %H:%M:%S')],
-                ['Cashier:', sale.cashier or 'System'],
+                ['Cashier:', sale.user.username if sale.user else 'System'],
                 ['Customer:', sale.customer.name if sale.customer else 'Walk-in Customer']
             ]
             
@@ -236,7 +236,7 @@ class ReceiptPrinter:
             receipt_lines.append("")
             receipt_lines.append(f"Receipt #: {sale.sale_number}")
             receipt_lines.append(f"Date: {sale.created_at.strftime('%Y-%m-%d %H:%M:%S')}")
-            receipt_lines.append(f"Cashier: {sale.cashier or 'System'}")
+            receipt_lines.append(f"Cashier: {sale.user.username if sale.user else 'System'}")
             customer_name = sale.customer.name if sale.customer else 'Walk-in Customer'
             receipt_lines.append(f"Customer: {customer_name}")
             receipt_lines.append("-" * 40)

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,0 +1,27 @@
+"""Simple authentication utilities."""
+
+import hashlib
+
+_current_user = None
+
+
+def hash_password(password: str) -> str:
+    """Return a SHA-256 hash for the given password."""
+    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    """Verify a password against an existing hash."""
+    return hash_password(password) == password_hash
+
+
+def set_current_user(user):
+    """Store the currently authenticated user."""
+    global _current_user
+    _current_user = user
+
+
+def get_current_user():
+    """Get the currently authenticated user, if any."""
+    return _current_user
+

--- a/utils/backup.py
+++ b/utils/backup.py
@@ -1,0 +1,14 @@
+
+import os
+from datetime import datetime
+
+from database.database import db_manager
+
+
+def create_backup(directory: str = "backups") -> str:
+    """Create a timestamped copy of the database file."""
+    os.makedirs(directory, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = os.path.join(directory, f"construction_pos_{timestamp}.db")
+    db_manager.backup_database(backup_path)
+    return backup_path


### PR DESCRIPTION
## Summary
- add persistent User model and tie Sale records to a user
- introduce login window and authentication utilities for cashier tracking
- include simple database backup helper

## Testing
- `pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_6891deda9ae4832cbb80c3b18da0c6f3