### PR TITLE
Fix circular import in utils package

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,8 +1,7 @@
 # utils/__init__.py
 """Utilities package for Construction POS System"""
 
-from .receipt_printer import ReceiptPrinter
+# Intentionally avoid importing submodules at package import time to prevent
+# circular import issues. Modules should be imported explicitly where needed.
 
-__all__ = [
-    'ReceiptPrinter'
-]
+__all__ = []


### PR DESCRIPTION
## Summary
- avoid importing `ReceiptPrinter` on utils package import to prevent circular dependency

## Testing
- `python main.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6891eeebebe0832c977447f75a61988b