### PR TITLE
Ensure inventory updates are visible

### DIFF
--- a/gui/inventory_window.py
+++ b/gui/inventory_window.py
@@ -463,6 +463,8 @@ class InventoryWindow:
                 session.add(product)
                 session.commit()
                 messagebox.showinfo("Success", "Product added successfully!")
+                # Clear any active search so the new product is visible
+                self.product_search_var.set('')
                 self.refresh_products()
                 self.refresh_alerts()
                 self.notify_change()
@@ -495,6 +497,8 @@ class InventoryWindow:
 
                 session.commit()
                 messagebox.showinfo("Success", "Product updated successfully!")
+                # Reset search to ensure updated product is shown
+                self.product_search_var.set('')
                 self.refresh_products()
                 self.refresh_alerts()
                 self.notify_change()
@@ -526,6 +530,8 @@ class InventoryWindow:
                 product.is_active = False
                 session.commit()
                 messagebox.showinfo("Success", "Product deactivated successfully!")
+                # Clear search so deactivated product disappears consistently
+                self.product_search_var.set('')
                 self.refresh_products()
                 self.notify_change()
                 
@@ -711,9 +717,11 @@ class InventoryWindow:
                 created_by="System"
             )
             session.add(movement)
-            
+
             session.commit()
             messagebox.showinfo("Success", "Stock movement processed successfully!")
+            # Clear search so stock updates are always visible
+            self.product_search_var.set('')
             self.refresh_products()
             self.refresh_movements()
             self.refresh_alerts()


### PR DESCRIPTION
## Summary
- Clear product search filter after adding, editing, deleting, or adjusting stock so changes appear immediately

## Testing
- `python -m pytest`
- `python -m py_compile gui/inventory_window.py`


------
https://chatgpt.com/codex/tasks/task_e_689306ec952c832cb9dd7d98cbe581e9