### PR TITLE
feat: add customer and settings enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Construction Materials POS System
+# Quincaillerie Fexson POS System
 
 A complete offline Point of Sale system designed specifically for construction material shops (quincailleries). Built with Python and Tkinter for reliability and ease of use.
 

--- a/database/database.py
+++ b/database/database.py
@@ -321,11 +321,13 @@ def init_database():
             from .models import Setting, User
             
             default_settings = [
-                {"key": "shop_name", "value": "Construction Materials Shop", "description": "Shop name"},
+                {"key": "shop_name", "value": "Quincaillerie Fexson", "description": "Shop name"},
                 {"key": "shop_address", "value": "123 Main Street", "description": "Shop address"},
                 {"key": "shop_phone", "value": "+1234567890", "description": "Shop phone"},
                 {"key": "tax_rate", "value": "18.0", "description": "Tax rate percentage"},
                 {"key": "currency", "value": "FCFA", "description": "Currency symbol"},
+                {"key": "language", "value": "en", "description": "UI language"},
+                {"key": "theme", "value": "light", "description": "UI theme"},
                 {"key": "receipt_footer", "value": "Thank you for your business!", "description": "Receipt footer text"}
             ]
             

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,10 +1,13 @@
 import tkinter as tk
 from tkinter import ttk
 from datetime import datetime
+from database.database import DatabaseUtils
+from utils.i18n import translate as _
 from .pos_window import POSWindow
 from .inventory_window import InventoryWindow
 from .reports_window import ReportsWindow
 from .customers_window import CustomersWindow
+from .settings_window import SettingsWindow
 
 class MainWindow:
     """Main application window with navigation."""
@@ -35,7 +38,8 @@ class MainWindow:
         header = ttk.Frame(self.main_frame)
         header.grid(row=0, column=0, columnspan=2, sticky="ew", pady=(0, 10))
         header.columnconfigure(1, weight=1)
-        ttk.Label(header, text="Construction Materials POS", style='Title.TLabel').grid(row=0, column=0, sticky="w")
+        app_name = DatabaseUtils.get_setting_value('shop_name', 'Quincaillerie Fexson')
+        ttk.Label(header, text=app_name, style='Title.TLabel').grid(row=0, column=0, sticky="w")
         self.time_label = ttk.Label(header, text="", font=('Arial', 10))
         self.time_label.grid(row=0, column=2, sticky="e")
         self.update_time()
@@ -48,11 +52,11 @@ class MainWindow:
         sidebar = ttk.LabelFrame(self.main_frame, text="Navigation", padding="10")
         sidebar.grid(row=1, column=0, sticky="ns")
         buttons = [
-            ("🛒 Point of Sale", self.show_pos),
-            ("📦 Inventory", self.show_inventory),
-            ("📊 Reports", self.show_reports),
-            ("👥 Customers", self.show_customers),
-            ("⚙️ Settings", self.show_settings),
+            (f"🛒 { _('pos') }", self.show_pos),
+            (f"📦 { _('inventory') }", self.show_inventory),
+            (f"📊 { _('reports') }", self.show_reports),
+            (f"👥 { _('customers') }", self.show_customers),
+            (f"⚙️ { _('settings') }", self.show_settings),
         ]
         for i, (text, cmd) in enumerate(buttons):
             ttk.Button(sidebar, text=text, command=cmd, style='Large.TButton', width=15).grid(row=i, column=0, pady=5, sticky="ew")
@@ -90,5 +94,5 @@ class MainWindow:
 
     def show_settings(self):
         self.clear_content()
-        ttk.Label(self.content_frame, text="Settings\n(Coming Soon)", font=('Arial', 16)).grid(row=0, column=0, sticky="nsew")
-        self.update_status("Settings")
+        self.current_window = SettingsWindow(self.content_frame, self.root)
+        self.update_status(_("settings"))

--- a/gui/pos_window.py
+++ b/gui/pos_window.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from database.database import db_manager, DatabaseUtils
 from database.models import Product, Sale, SaleItem, Customer, StockMovement
 from utils.auth import get_current_user
+from utils.i18n import translate as _
 from sqlalchemy import func
 
 class POSWindow:
@@ -110,13 +111,17 @@ class POSWindow:
         dashboard_frame = ttk.LabelFrame(self.left_panel, text="Dashboard", padding="5")
         dashboard_frame.grid(row=2, column=0, sticky=(tk.W, tk.E), padx=5, pady=5)
 
-        ttk.Label(dashboard_frame, text="Total Sales:").grid(row=0, column=0, sticky=tk.W)
+        ttk.Label(dashboard_frame, text=_("total_sales")).grid(row=0, column=0, sticky=tk.W)
         self.total_sales_var = tk.StringVar(value="0")
         ttk.Label(dashboard_frame, textvariable=self.total_sales_var).grid(row=0, column=1, sticky=tk.W)
 
-        ttk.Label(dashboard_frame, text="Low Stock Items:").grid(row=1, column=0, sticky=tk.W)
+        ttk.Label(dashboard_frame, text=_("revenue")).grid(row=1, column=0, sticky=tk.W)
+        self.revenue_var = tk.StringVar(value="0")
+        ttk.Label(dashboard_frame, textvariable=self.revenue_var).grid(row=1, column=1, sticky=tk.W)
+
+        ttk.Label(dashboard_frame, text=_("low_stock")).grid(row=2, column=0, sticky=tk.W)
         self.low_stock_var = tk.StringVar(value="0")
-        ttk.Label(dashboard_frame, textvariable=self.low_stock_var).grid(row=1, column=1, sticky=tk.W)
+        ttk.Label(dashboard_frame, textvariable=self.low_stock_var).grid(row=2, column=1, sticky=tk.W)
     
     def setup_right_panel(self):
         """Setup right panel with cart and checkout"""
@@ -125,9 +130,9 @@ class POSWindow:
         customer_frame.grid(row=0, column=0, sticky=(tk.W, tk.E), padx=5, pady=5)
         customer_frame.columnconfigure(1, weight=1)
         
-        ttk.Label(customer_frame, text="Customer:").grid(row=0, column=0, sticky=tk.W)
+        ttk.Label(customer_frame, text=f"{ _('customer') }:").grid(row=0, column=0, sticky=tk.W)
         self.customer_var = tk.StringVar()
-        self.customer_combo = ttk.Combobox(customer_frame, textvariable=self.customer_var, state="readonly")
+        self.customer_combo = ttk.Combobox(customer_frame, textvariable=self.customer_var, state="normal")
         self.customer_combo.grid(row=0, column=1, sticky=(tk.W, tk.E), padx=(5, 0))
         
         # Shopping cart
@@ -171,14 +176,19 @@ class POSWindow:
         ttk.Label(totals_frame, text="Subtotal:").grid(row=0, column=0, sticky=tk.W)
         self.subtotal_label = ttk.Label(totals_frame, text="0.00", font=('Arial', 12, 'bold'))
         self.subtotal_label.grid(row=0, column=1, sticky=tk.E)
-        
-        ttk.Label(totals_frame, text="Tax:").grid(row=1, column=0, sticky=tk.W)
+
+        ttk.Label(totals_frame, text=f"{ _('tax_rate') }:").grid(row=1, column=0, sticky=tk.W)
+        self.tax_rate_var = tk.StringVar(value=DatabaseUtils.get_setting_value('tax_rate', '0'))
+        ttk.Entry(totals_frame, textvariable=self.tax_rate_var, width=10).grid(row=1, column=1, sticky=tk.E)
+        self.tax_rate_var.trace('w', lambda *args: self.calculate_totals())
+
+        ttk.Label(totals_frame, text=f"{ _('tax_amount') }:").grid(row=2, column=0, sticky=tk.W)
         self.tax_label = ttk.Label(totals_frame, text="0.00")
-        self.tax_label.grid(row=1, column=1, sticky=tk.E)
-        
-        ttk.Label(totals_frame, text="Total:").grid(row=2, column=0, sticky=tk.W)
+        self.tax_label.grid(row=2, column=1, sticky=tk.E)
+
+        ttk.Label(totals_frame, text=f"{ _('total') }:").grid(row=3, column=0, sticky=tk.W)
         self.total_label = ttk.Label(totals_frame, text="0.00", font=('Arial', 14, 'bold'))
-        self.total_label.grid(row=2, column=1, sticky=tk.E)
+        self.total_label.grid(row=3, column=1, sticky=tk.E)
         
         # Payment section
         payment_frame = ttk.LabelFrame(self.right_panel, text="Payment", padding="10")
@@ -304,12 +314,15 @@ class POSWindow:
         session = db_manager.get_session()
         try:
             total_sales = session.query(func.count(Sale.id)).scalar() or 0
+            revenue = session.query(func.sum(Sale.total_amount)).scalar() or 0
             low_stock = session.query(func.count(Product.id)).filter(
                 Product.is_active == True,
                 Product.stock_quantity <= Product.min_stock_level
             ).scalar() or 0
 
+            currency = DatabaseUtils.get_setting_value('currency', 'FCFA')
             self.total_sales_var.set(str(total_sales))
+            self.revenue_var.set(f"{revenue:,.0f} {currency}")
             self.low_stock_var.set(str(low_stock))
         finally:
             session.close()
@@ -464,8 +477,8 @@ class POSWindow:
         """Calculate and display totals"""
         subtotal = sum(item['total'] for item in self.cart_items)
         
-        # Get tax rate from settings
-        tax_rate = float(DatabaseUtils.get_setting_value('tax_rate', '0'))
+        # Get tax rate from user input
+        tax_rate = float(self.tax_rate_var.get() or 0)
         tax_amount = subtotal * (tax_rate / 100)
         total = subtotal + tax_amount
         
@@ -485,7 +498,7 @@ class POSWindow:
         """Calculate change amount"""
         try:
             total = sum(item['total'] for item in self.cart_items)
-            tax_rate = float(DatabaseUtils.get_setting_value('tax_rate', '0'))
+            tax_rate = float(self.tax_rate_var.get() or 0)
             total_with_tax = total * (1 + tax_rate / 100)
             
             paid = float(self.paid_var.get() or 0)
@@ -573,35 +586,38 @@ class POSWindow:
         # Validate payment
         try:
             total = sum(item['total'] for item in self.cart_items)
-            tax_rate = float(DatabaseUtils.get_setting_value('tax_rate', '0'))
+            tax_rate = float(self.tax_rate_var.get() or 0)
             tax_amount = total * (tax_rate / 100)
             total_with_tax = total + tax_amount
-            
+
             paid = float(self.paid_var.get() or 0)
-            
+
             if self.payment_var.get() == "cash" and paid < total_with_tax:
                 messagebox.showwarning("Insufficient Payment", "Payment amount is less than total.")
                 return
-                
+
         except ValueError:
             messagebox.showwarning("Invalid Payment", "Please enter a valid payment amount.")
             return
-        
-        # Get customer
-        customer_id = None
-        customer_text = self.customer_var.get()
-        if customer_text:
-            customer_id = int(customer_text.split(' - ')[0])
 
-        # Create default numbered customer if none selected
+        # Determine customer (existing or new)
+        customer_text = self.customer_var.get().strip()
         session = db_manager.get_session()
         try:
-            if customer_id is None:
-                next_num = session.query(func.count(Customer.id)).scalar() + 1
-                customer = Customer(name=f"Customer {next_num}")
+            if customer_text and ' - ' in customer_text and customer_text.split(' - ')[0].isdigit():
+                customer_id = int(customer_text.split(' - ')[0])
+            else:
+                if not customer_text:
+                    next_num = session.query(func.count(Customer.id)).scalar() + 1
+                    customer_text = f"Customer {next_num}"
+                customer = Customer(name=customer_text)
                 session.add(customer)
-                session.flush()
+                session.commit()
                 customer_id = customer.id
+        except Exception as e:
+            session.rollback()
+            messagebox.showerror("Customer Error", f"Failed to save customer: {e}")
+            return
         finally:
             session.close()
 
@@ -679,8 +695,8 @@ class POSWindow:
         try:
             from utils.receipt_printer import ReceiptPrinter
             printer = ReceiptPrinter()
-            printer.generate_receipt(sale)
-            messagebox.showinfo("Receipt", "Receipt generated successfully!")
+            receipt_path = printer.generate_receipt(sale)
+            messagebox.showinfo("Receipt", f"Receipt saved to:\n{receipt_path}")
         except Exception as e:
             messagebox.showerror("Print Error", f"Failed to print receipt: {e}")
     
@@ -701,9 +717,8 @@ class POSWindow:
         self.paid_var.set("")
         self.search_var.set("")
 
-        # Reset to default customer
-        if self.customer_combo['values']:
-            self.customer_combo.set(self.customer_combo['values'][0])
+        # Reload customers to include new entries and reset selection
+        self.load_customers()
 
         # Focus search box and refresh product list
         self.search_var.set("")

--- a/gui/settings_window.py
+++ b/gui/settings_window.py
@@ -1,0 +1,88 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from database.database import db_manager, DatabaseUtils
+from database.models import User
+from utils.auth import hash_password
+from utils.i18n import translate as _
+
+
+class SettingsWindow:
+    """Settings window for user management and preferences."""
+
+    def __init__(self, parent, root):
+        self.parent = parent
+        self.root = root
+        self.setup_ui()
+
+    def setup_ui(self):
+        notebook = ttk.Notebook(self.parent)
+        notebook.pack(fill="both", expand=True)
+
+        # Users tab
+        user_frame = ttk.Frame(notebook, padding=10)
+        notebook.add(user_frame, text=_('users'))
+
+        ttk.Label(user_frame, text=_('username')).grid(row=0, column=0, sticky=tk.W)
+        self.username_var = tk.StringVar()
+        ttk.Entry(user_frame, textvariable=self.username_var).grid(row=0, column=1, sticky=(tk.W, tk.E), pady=5)
+
+        ttk.Label(user_frame, text=_('password')).grid(row=1, column=0, sticky=tk.W)
+        self.password_var = tk.StringVar()
+        ttk.Entry(user_frame, textvariable=self.password_var, show='*').grid(row=1, column=1, sticky=(tk.W, tk.E), pady=5)
+
+        ttk.Button(user_frame, text=_('add_user'), command=self.add_user).grid(row=2, column=0, columnspan=2, pady=10, sticky=(tk.W, tk.E))
+        user_frame.columnconfigure(1, weight=1)
+
+        # Preferences tab
+        pref_frame = ttk.Frame(notebook, padding=10)
+        notebook.add(pref_frame, text=_('preferences'))
+
+        ttk.Label(pref_frame, text=_('language')).grid(row=0, column=0, sticky=tk.W)
+        self.lang_var = tk.StringVar(value=DatabaseUtils.get_setting_value('language', 'en'))
+        lang_combo = ttk.Combobox(pref_frame, textvariable=self.lang_var, values=['en', 'fr'], state='readonly')
+        lang_combo.grid(row=0, column=1, sticky=(tk.W, tk.E), pady=5)
+
+        ttk.Label(pref_frame, text=_('theme')).grid(row=1, column=0, sticky=tk.W)
+        self.theme_var = tk.StringVar(value=DatabaseUtils.get_setting_value('theme', 'light'))
+        theme_combo = ttk.Combobox(pref_frame, textvariable=self.theme_var, values=['light', 'dark'], state='readonly')
+        theme_combo.grid(row=1, column=1, sticky=(tk.W, tk.E), pady=5)
+
+        ttk.Button(pref_frame, text=_('save_preferences'), command=self.save_preferences).grid(row=2, column=0, columnspan=2, pady=10, sticky=(tk.W, tk.E))
+        pref_frame.columnconfigure(1, weight=1)
+
+    def add_user(self):
+        username = self.username_var.get().strip()
+        password = self.password_var.get()
+        if not username or not password:
+            messagebox.showerror(_('settings'), _('username') + ' & ' + _('password') + ' required')
+            return
+        session = db_manager.get_session()
+        try:
+            if session.query(User).filter(User.username == username).first():
+                messagebox.showerror(_('settings'), 'Username exists')
+                return
+            user = User(username=username, password_hash=hash_password(password))
+            session.add(user)
+            session.commit()
+            messagebox.showinfo(_('settings'), _( 'user_added'))
+            self.username_var.set('')
+            self.password_var.set('')
+        finally:
+            session.close()
+
+    def save_preferences(self):
+        DatabaseUtils.update_setting('language', self.lang_var.get())
+        DatabaseUtils.update_setting('theme', self.theme_var.get())
+        messagebox.showinfo(_('settings'), _('save_preferences'))
+        # Notify root to reapply theme if possible
+        try:
+            from .main_window import MainWindow  # avoid circular if possible
+            style = ttk.Style()
+            if self.theme_var.get() == 'dark':
+                style.theme_use('alt')
+                self.root.configure(background='#2c3e50')
+            else:
+                style.theme_use('clam')
+                self.root.configure(background='white')
+        except Exception:
+            pass

--- a/main.py
+++ b/main.py
@@ -319,7 +319,8 @@ except ImportError:
 class ConstructionPOSApp:
     def __init__(self):
         self.root = tk.Tk()
-        self.root.title("Construction Materials POS System")
+        app_name = DatabaseUtils.get_setting_value('shop_name', 'Quincaillerie Fexson')
+        self.root.title(app_name)
         self.root.geometry("1200x800")
         
         # Try to maximize window
@@ -361,28 +362,39 @@ class ConstructionPOSApp:
     def setup_modern_theme(self):
         """Setup modern professional theme"""
         style = ttk.Style()
-        
-        # Use a modern theme as base
+        theme_setting = DatabaseUtils.get_setting_value('theme', 'light')
         try:
-            style.theme_use('clam')
-        except:
-            try:
-                style.theme_use('vista')
-            except:
-                style.theme_use('default')
-        
-        # Define modern color palette
-        colors = {
-            'primary': '#2c3e50',      # Dark blue-gray
-            'secondary': '#3498db',     # Blue
-            'success': '#27ae60',       # Green
-            'warning': '#f39c12',       # Orange
-            'danger': '#e74c3c',        # Red
-            'light': '#ecf0f1',         # Light gray
-            'dark': '#34495e',          # Dark gray
-            'white': '#ffffff',
-            'accent': '#9b59b6'         # Purple
-        }
+            style.theme_use('alt' if theme_setting == 'dark' else 'clam')
+        except Exception:
+            style.theme_use('default')
+
+        # Define color palette based on theme
+        if theme_setting == 'dark':
+            colors = {
+                'primary': '#ecf0f1',
+                'secondary': '#3498db',
+                'success': '#27ae60',
+                'warning': '#f39c12',
+                'danger': '#e74c3c',
+                'light': '#2c3e50',
+                'dark': '#ecf0f1',
+                'white': '#34495e',
+                'accent': '#9b59b6'
+            }
+            self.root.configure(background='#2c3e50')
+        else:
+            colors = {
+                'primary': '#2c3e50',
+                'secondary': '#3498db',
+                'success': '#27ae60',
+                'warning': '#f39c12',
+                'danger': '#e74c3c',
+                'light': '#ecf0f1',
+                'dark': '#34495e',
+                'white': '#ffffff',
+                'accent': '#9b59b6'
+            }
+            self.root.configure(background='white')
         
         # Configure modern styles
         

--- a/utils/i18n.py
+++ b/utils/i18n.py
@@ -1,0 +1,56 @@
+from database.database import DatabaseUtils
+
+TRANSLATIONS = {
+    'en': {
+        'customer': 'Customer',
+        'tax_rate': 'Tax Rate (%)',
+        'tax_amount': 'Tax Amount',
+        'total': 'Total',
+        'total_sales': 'Total Sales',
+        'revenue': 'Revenue',
+        'low_stock': 'Low Stock Items',
+        'language': 'Language',
+        'theme': 'Theme',
+        'settings': 'Settings',
+        'users': 'Users',
+        'preferences': 'Preferences',
+        'username': 'Username',
+        'password': 'Password',
+        'add_user': 'Add User',
+        'save_preferences': 'Save Preferences',
+        'user_added': 'User added successfully',
+        'pos': 'Point of Sale',
+        'inventory': 'Inventory',
+        'reports': 'Reports',
+        'customers': 'Customers',
+    },
+    'fr': {
+        'customer': 'Client',
+        'tax_rate': 'Tax (%)',
+        'tax_amount': 'Montant Taxe',
+        'total': 'Total',
+        'total_sales': 'Ventes',
+        'revenue': 'Revenu',
+        'low_stock': 'Stock Faible',
+        'language': 'Langue',
+        'theme': 'Thème',
+        'settings': 'Paramètres',
+        'users': 'Utilisateurs',
+        'preferences': 'Préférences',
+        'username': 'Nom d\u2019utilisateur',
+        'password': 'Mot de passe',
+        'add_user': 'Ajouter',
+        'save_preferences': 'Enregistrer',
+        'user_added': 'Utilisateur ajouté',
+        'pos': 'Point de Vente',
+        'inventory': 'Inventaire',
+        'reports': 'Rapports',
+        'customers': 'Clients',
+    },
+}
+
+
+def translate(key: str) -> str:
+    """Translate a key based on current language setting."""
+    lang = DatabaseUtils.get_setting_value('language', 'en')
+    return TRANSLATIONS.get(lang, TRANSLATIONS['en']).get(key, key)

--- a/utils/receipt_printer.py
+++ b/utils/receipt_printer.py
@@ -5,7 +5,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
 from reportlab.lib import colors
 from reportlab.pdfgen import canvas
-from database.database import DatabaseUtils
+from database.database import DatabaseUtils, get_app_dir
 from datetime import datetime
 import os
 
@@ -73,10 +73,10 @@ class ReceiptPrinter:
     def generate_receipt(self, sale):
         """Generate PDF receipt for a sale"""
         try:
-            # Create receipts directory if it doesn't exist
-            receipts_dir = "receipts"
+            # Create receipts directory inside the application folder
+            receipts_dir = os.path.join(get_app_dir(), "receipts")
             if not os.path.exists(receipts_dir):
-                os.makedirs(receipts_dir)
+                os.makedirs(receipts_dir, exist_ok=True)
             
             # Generate filename
             filename = f"receipt_{sale.sale_number}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf"
@@ -96,7 +96,7 @@ class ReceiptPrinter:
             story = []
             
             # Shop header
-            shop_name = DatabaseUtils.get_setting_value('shop_name', 'Construction Materials Shop')
+            shop_name = DatabaseUtils.get_setting_value('shop_name', 'Quincaillerie Fexson')
             shop_address = DatabaseUtils.get_setting_value('shop_address', '123 Main Street')
             shop_phone = DatabaseUtils.get_setting_value('shop_phone', '+1234567890')
             
@@ -204,17 +204,17 @@ class ReceiptPrinter:
     def generate_simple_receipt(self, sale):
         """Generate a simple text receipt for thermal printers"""
         try:
-            # Create receipts directory if it doesn't exist
-            receipts_dir = "receipts"
+            # Create receipts directory inside the application folder
+            receipts_dir = os.path.join(get_app_dir(), "receipts")
             if not os.path.exists(receipts_dir):
-                os.makedirs(receipts_dir)
+                os.makedirs(receipts_dir, exist_ok=True)
             
             # Generate filename
             filename = f"receipt_{sale.sale_number}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
             filepath = os.path.join(receipts_dir, filename)
             
             # Get settings
-            shop_name = DatabaseUtils.get_setting_value('shop_name', 'Construction Materials Shop')
+            shop_name = DatabaseUtils.get_setting_value('shop_name', 'Quincaillerie Fexson')
             shop_address = DatabaseUtils.get_setting_value('shop_address', '123 Main Street')
             shop_phone = DatabaseUtils.get_setting_value('shop_phone', '+1234567890')
             currency = DatabaseUtils.get_setting_value('currency', 'FCFA')
@@ -340,7 +340,7 @@ class ReceiptPrinter:
             Date: {datetime.now().strftime('%Y-%m-%d')}
             
             Best regards,
-            {DatabaseUtils.get_setting_value('shop_name', 'Construction Materials Shop')}
+            {DatabaseUtils.get_setting_value('shop_name', 'Quincaillerie Fexson')}
             """
             
             msg.attach(MIMEText(body, 'plain'))
@@ -409,7 +409,7 @@ class ReceiptPrinter:
             story = []
             
             # Report header
-            shop_name = DatabaseUtils.get_setting_value('shop_name', 'Construction Materials Shop')
+            shop_name = DatabaseUtils.get_setting_value('shop_name', 'Quincaillerie Fexson')
             story.append(Paragraph(shop_name, self.styles['ShopName']))
             story.append(Paragraph(f"Daily Sales Report - {date.strftime('%Y-%m-%d')}", self.styles['ReceiptHeader']))
             story.append(Spacer(1, 12))


### PR DESCRIPTION
## Summary
- allow entering custom customer names and tax rates during POS checkout
- show revenue stats on POS dashboard and rename app to **Quincaillerie Fexson**
- add settings window for user management, language and theme preferences
- persist new customer names so sales appear under the correct customer and reload customer list after each sale
- store receipts in an app-level `receipts` folder and show the saved path after each sale

## Testing
- `python -m py_compile database/database.py gui/main_window.py gui/pos_window.py gui/settings_window.py main.py utils/receipt_printer.py utils/i18n.py gui/customers_window.py`


------
https://chatgpt.com/codex/tasks/task_e_689314b887e0832ca6d04d446b9f5333